### PR TITLE
Items endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
+gem 'jsonapi-serializer'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -170,6 +172,7 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   faker
+  jsonapi-serializer
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -3,4 +3,8 @@ class Api::V1::ItemsController < ApplicationController
   def index
     render json: ItemSerializer.new(Item.all)
   end
+
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ItemsController < ApplicationController
 
   def index
-    render json: Item.all
+    render json: ItemSerializer.new(Item.all)
   end
 end

--- a/app/controllers/api/v1/merchant_items_controller.rb
+++ b/app/controllers/api/v1/merchant_items_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::MerchantItemsController < ApplicationController
 
   def index
-    render json: Item.where(merchant_id: params[:merchant_id])
+    render json: ItemSerializer.new(Item.where(merchant_id: params[:merchant_id]))
   end
 
 

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,10 +1,10 @@
 class Api::V1::MerchantsController < ApplicationController
 
   def index
-    render json: Merchant.all
+    render json: MerchantSerializer.new(Merchant.all)
   end
 
   def show
-    render json: Merchant.find(params[:id])
+    render json: MerchantSerializer.new(Merchant.find(params[:id]))
   end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,5 @@
+class ItemSerializer
+  include JSONAPI::Serializer
+  attributes :id, :name, :unit_price, :description
+  belongs_to :merchant
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,5 +1,5 @@
 class ItemSerializer
   include JSONAPI::Serializer
-  attributes :id, :name, :unit_price, :description
-  belongs_to :merchant
+  attributes :name, :unit_price, :description, :merchant_id
+  # belongs_to :merchant
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,5 @@
+class MerchantSerializer
+  include JSONAPI::Serializer
+  attributes :id, :name
+  # has_many :items
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,5 +1,5 @@
 class MerchantSerializer
   include JSONAPI::Serializer
-  attributes :id, :name
+  attributes :name
   # has_many :items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :merchants do
         resources :items, controller: 'merchant_items'
       end
-      resources :items, only: [:index]
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :item do
-    name { Faker::Name.name }
+    name { Faker::Commerce.product_name }
     description { Faker::Lorem.paragraph }
     unit_price { Faker::Number.decimal(l_digits: 2) }
     merchant_id { Faker::Number.between(from: 1, to: 10) }

--- a/spec/requests/api/v1/item_request_spec.rb
+++ b/spec/requests/api/v1/item_request_spec.rb
@@ -2,10 +2,26 @@ require 'rails_helper'
 
 RSpec.describe 'Item Requests' do
   it 'can send a list of items' do
+    create_list(:merchant, 10)
     create_list(:item, 10)
 
-    visit '/api/v1/items'
+    get '/api/v1/items'
 
     expect(response).to be_successful
+    items = JSON.parse(response.body, symbolize_names: true)
+
+    expect(items.count).to eq(10)
+    items.each do |item|
+      expect(item).to have_key(:id)
+      expect(item[:id]).to be_a(Integer)
+      expect(item).to have_key(:name)
+      expect(item[:name]).to be_a(String)
+      expect(item).to have_key(:description)
+      expect(item[:description]).to be_a(String)
+      expect(item).to have_key(:unit_price)
+      expect(item[:unit_price]).to be_a(Float)
+      expect(item).to have_key(:merchant_id)
+      expect(item[:merchant_id]).to be_a(Integer)
+    end
   end
 end

--- a/spec/requests/api/v1/item_request_spec.rb
+++ b/spec/requests/api/v1/item_request_spec.rb
@@ -8,20 +8,22 @@ RSpec.describe 'Item Requests' do
     get '/api/v1/items'
 
     expect(response).to be_successful
-    items = JSON.parse(response.body, symbolize_names: true)
-
+    parsed = JSON.parse(response.body, symbolize_names: true)
+    items = parsed[:data]
     expect(items.count).to eq(10)
+
     items.each do |item|
       expect(item).to have_key(:id)
-      expect(item[:id]).to be_a(Integer)
-      expect(item).to have_key(:name)
-      expect(item[:name]).to be_a(String)
-      expect(item).to have_key(:description)
-      expect(item[:description]).to be_a(String)
-      expect(item).to have_key(:unit_price)
-      expect(item[:unit_price]).to be_a(Float)
-      expect(item).to have_key(:merchant_id)
-      expect(item[:merchant_id]).to be_a(Integer)
+      expect(item[:id]).to be_a(String)
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes][:name]).to be_a(String)
+      expect(item[:attributes]).to have_key(:description)
+      expect(item[:attributes][:description]).to be_a(String)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes][:unit_price]).to be_a(Float)
     end
+  end
+
+  it 'can send a single item' do
   end
 end

--- a/spec/requests/api/v1/item_request_spec.rb
+++ b/spec/requests/api/v1/item_request_spec.rb
@@ -25,5 +25,21 @@ RSpec.describe 'Item Requests' do
   end
 
   it 'can send a single item' do
+    merchant = Merchant.create({name: "Big Dave's House of Pickles"})
+    item_1 = merchant.items.create({name: "Pickle Dress", description: "Dress for big dill nights", unit_price: 9.99})
+    item_2 = merchant.items.create({name: "Pickles", description: "Just tasty pickles", unit_price: 0.99})
+
+    get "/api/v1/items/#{item_1.id}"
+
+    expect(response).to be_successful
+
+    item = JSON.parse(response.body, symbolize_names: true)
+    # require "pry"; binding.pry
+    expect(item[:data]).to have_key(:id)
+    expect(item[:data][:id]).to be_a(String)
+    expect(item[:data][:attributes]).to have_key(:name)
+    expect(item[:data][:attributes][:name]).to be_a(String)
+    expect(item[:data][:attributes]).to have_key(:unit_price)
+    expect(item[:data][:attributes][:unit_price]).to be_a(Float)
   end
 end

--- a/spec/requests/api/v1/merchant_request_spec.rb
+++ b/spec/requests/api/v1/merchant_request_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'Merchant Request' do
     merchants = parsed[:data]
 
     merchants.each do |merchant|
-      expect(merchant[:attributes]).to have_key(:id)
-      expect(merchant[:attributes][:id]).to be_a(Integer)
+      expect(merchant).to have_key(:id)
+      expect(merchant[:id]).to be_a(String)
       expect(merchant[:attributes]).to have_key(:name)
       expect(merchant[:attributes][:name]).to be_a(String)
     end
@@ -41,19 +41,20 @@ RSpec.describe 'Merchant Request' do
 
     get "/api/v1/merchants/#{merchant.id}/items"
 
-    items = JSON.parse(response.body, symbolize_names: true)
+    parsed = JSON.parse(response.body, symbolize_names: true)
+    items = parsed[:data]
 
     expect(items.count).to eq(2)
     items.each do |item|
       expect(item).to have_key(:id)
-      expect(item[:id]).to be_a(Integer)
-      expect(item).to have_key(:name)
-      expect(item[:name]).to be_a(String)
-      expect(item).to have_key(:unit_price)
-      expect(item[:unit_price]).to be_a(Float)
-      expect(item).to have_key(:merchant_id)
-      expect(item[:merchant_id]).to be_a(Integer)
-      expect(item[:merchant_id]).to eq(merchant.id)
+      expect(item[:id]).to be_a(String)
+      expect(item[:attributes]).to have_key(:name)
+      expect(item[:attributes][:name]).to be_a(String)
+      expect(item[:attributes]).to have_key(:unit_price)
+      expect(item[:attributes][:unit_price]).to be_a(Float)
+      expect(item[:attributes]).to have_key(:merchant_id)
+      expect(item[:attributes][:merchant_id]).to be_a(Integer)
+      expect(item[:attributes][:merchant_id]).to eq(merchant.id)
     end
   end
 

--- a/spec/requests/api/v1/merchant_request_spec.rb
+++ b/spec/requests/api/v1/merchant_request_spec.rb
@@ -7,14 +7,15 @@ RSpec.describe 'Merchant Request' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body, symbolize_names: true)
-    expect(merchants.count).to eq(5)
+    parsed = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed[:data].count).to eq(5)
+    merchants = parsed[:data]
 
     merchants.each do |merchant|
-      expect(merchant).to have_key(:id)
-      expect(merchant[:id]).to be_a(Integer)
-      expect(merchant).to have_key(:name)
-      expect(merchant[:name]).to be_a(String)
+      expect(merchant[:attributes]).to have_key(:id)
+      expect(merchant[:attributes][:id]).to be_a(Integer)
+      expect(merchant[:attributes]).to have_key(:name)
+      expect(merchant[:attributes][:name]).to be_a(String)
     end
   end
 
@@ -23,11 +24,12 @@ RSpec.describe 'Merchant Request' do
 
     get "/api/v1/merchants/#{id}"
 
-    merchant = JSON.parse(response.body, symbolize_names: true)
+    parsed = JSON.parse(response.body, symbolize_names: true)
+    merchant = parsed[:data]
 
     expect(response).to be_successful
-    expect(merchant).to have_key(:name)
-    expect(merchant[:name]).to be_a(String)
+    expect(merchant[:attributes]).to have_key(:name)
+    expect(merchant[:attributes][:name]).to be_a(String)
   end
 
   it 'can return all items of a given merchant' do


### PR DESCRIPTION
Adds jsonapi-serializer gem and serializers for merchant & items.

Serializers do not use has_many or belongs_to relationships to meet postman testing suite.

Still passes my own rspec testing for attributes and successfully reaching the API.